### PR TITLE
Use a different TF module for the test user

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Grab Tanium system package GPG key from S3
-  ansible.builtin.aws_s3:
+  amazon.aws.aws_s3:
     bucket: "{{ third_party_bucket_name }}"
     object: "{{ package_gpg_key_object_name }}"
     dest: /tmp/{{ package_gpg_key_object_name }}

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -14,7 +14,7 @@
     mode: 0700
     src: /tmp/{{ package_gpg_key_object_name }}
 
-- name: Import Tanimu system package GPG key
+- name: Import Tanium system package GPG key
   ansible.builtin.rpm_key:
     key: /tmp/{{ package_gpg_key_object_name }}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Install Tanium
   block:
     - name: Grab Tanium system package from S3
-      ansible.builtin.aws_s3:
+      amazon.aws.aws_s3:
         bucket: "{{ third_party_bucket_name }}"
         object: "{{ package_object_name }}"
         dest: /tmp/{{ package_object_name }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,6 @@
       paths:
         - "{{ role_path }}/vars"
 
-# Check if Tanium is already installed
 - name: Check if Tanium is already installed
   ansible.builtin.stat:
     path: "{{ install_directory }}"

--- a/terraform/user.tf
+++ b/terraform/user.tf
@@ -1,22 +1,19 @@
-# Create the test user
+# Create the test user.  We do not require SSM Parameter Store access
+# for this role, so we can simply use cisagov/ci-iam-user-tf-module
+# instead of cisagov/molecule-iam-user-tf-module.
 module "user" {
-  source = "github.com/cisagov/molecule-iam-user-tf-module"
+  source = "github.com/cisagov/ci-iam-user-tf-module"
 
   providers = {
-    aws                                    = aws.users
-    aws.images-production-provisionaccount = aws.images_production_provisionaccount
-    aws.images-staging-provisionaccount    = aws.images_staging_provisionaccount
-    aws.images-production-ssm              = aws.images_production_ssm
-    aws.images-staging-ssm                 = aws.images_staging_ssm
+    aws            = aws.users
+    aws.production = aws.images_production_provisionaccount
+    aws.staging    = aws.images_staging_provisionaccount
   }
 
-  entity = "ansible-role-venom-tanium-client"
-  # The TF module will error if we don't put at least one value here.
-  # This build user does not need to access any SSM parameters, so we
-  # just place a dummy value here.
-  ssm_parameters = ["/dummy/value"]
-
-  tags = var.tags
+  role_description = "A role that can be assumed to allow for CI testing of ansible-role-venom-tanium-client via Molecule."
+  role_name        = "Test-ansible-role-venom-tanium-client"
+  tags             = var.tags
+  user_name        = "test-ansible-role-venom-tanium-client"
 }
 
 # Attach third-party S3 bucket read-only policy to the production


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes the CI test user to use the [cisagov/ci-iam-user-tf-module](https://gtihub.com/cisagov/ci-iam-user-tf-module) Terraform module instead of [cisagov/molecule-iam-user-tf-module](https://github.com/cisagov/molecule-iam-user-tf-module).

## 💭 Motivation and context ##

* The test user for this role does not need to read any values from SSM Parameter Store, so it makes sense to use a Terraform module that does not offer that.  (I was previously giving the user permission to read the SSM parameter `/dummy/value`.)
* This issue was pointed out by @mcdonnnj in his post-merge review of cisagov/ansible-role-venom-tanium-client#2.

## 🧪 Testing ##

All `molecule` tests and `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
