### PR TITLE
Add Tanium initialization file and DHS PKI bundle to installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ None.
 
 ## Dependencies ##
 
+* [cisagov/ansible-role-dhs-certificates](https://github.com/cisagov/ansible-role-dhs-certificates)
 * [cisagov/ansible-role-venom-certificates](https://github.com/cisagov/ansible-role-venom-certificates)
 
 ## Example Playbook ##

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# A tanium initialization file containing Tanium configuration
+# A Tanium initialization file containing Tanium configuration
 # parameter values necessary to successfully connect to the VENOM
 # Tanium server
 initialization_file_object_name: tanium-init.dat

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+# A tanium initialization file containing Tanium configuration
+# parameter values necessary to successfully connect to the VENOM
+# Tanium server
+initialization_file_object_name: tanium-init.dat
+
 # The directory where Tanium is installed
 install_directory: /opt/Tanium/TaniumClient
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -39,5 +39,7 @@ galaxy_info:
   role_name: venom_tanium
 
 dependencies:
+  - src: https://github.com/cisagov/ansible-role-dhs-certificates
+    name: dhs_certificates
   - src: https://github.com/cisagov/ansible-role-venom-certificates
     name: venom_certificates

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,11 @@
   hosts: all
   roles:
     - role: ansible-role-venom-tanium-client
+  tasks:
+    # We want to force the Tanium client service to go ahead and
+    # start, since that will cause the initialization file to be read.
+    # We can then test that the registration secret was configured.
+    - name: Start the Tanium client service
+      ansible.builtin.service:
+        name: taniumclient
+        state: started

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,6 @@
 ---
+- src: https://github.com/cisagov/ansible-role-dhs-certificates
+  name: dhs_certificates
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
 - src: https://github.com/cisagov/ansible-role-python

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -29,7 +29,11 @@ def test_tanium_enabled(host):
 
 @pytest.mark.parametrize(
     "key, value",
-    [("ServerName", "tan-cosrvr-01.venom.cisa.gov"), ("ServerPort", "17472")],
+    [
+        ("RegistrationSecret", "(protected)"),
+        ("ServerName", "tan-cosrvr-01.venom.cisa.gov"),
+        ("ServerPort", "17472"),
+    ],
 )
 def test_tanium_config(host, key, value):
     """Test that TaniumClient is configured."""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,14 +17,17 @@
 
 - name: Install Tanium
   block:
-    - name: Grab Tanium system package from S3
+    - name: Grab Tanium system package and initialization file from S3
       amazon.aws.aws_s3:
         bucket: "{{ third_party_bucket_name }}"
-        object: "{{ package_object_name }}"
-        dest: /tmp/{{ package_object_name }}
+        object: "{{ item }}"
+        dest: /tmp/{{ item }}
         mode: get
       become: no
       delegate_to: localhost
+      loop:
+        - "{{ package_object_name }}"
+        - "{{ initialization_file_object_name }}"
 
     - name: Copy the Tanium system package
       ansible.builtin.copy:
@@ -49,12 +52,21 @@
     - name: Set the Tanium server port
       ansible.builtin.command: "{{ install_directory }}/TaniumClient config set-number ServerPort {{ server_port }}"
 
-    - name: Delete local copy of Tanium system package
+    - name: Copy the Tanium initialization file
+      ansible.builtin.copy:
+        dest: "{{ install_directory }}/{{ initialization_file_object_name }}"
+        mode: 0600
+        src: /tmp/{{ initialization_file_object_name }}
+
+    - name: Delete local copy of Tanium system package and initialization file
       ansible.builtin.file:
-        path: /tmp/{{ package_object_name }}
+        path: /tmp/{{ item }}
         state: absent
       become: no
       delegate_to: localhost
+      loop:
+        - "{{ package_object_name }}"
+        - "{{ initialization_file_object_name }}"
 
     - name: Delete remote copy of Tanium system package
       ansible.builtin.file:

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,6 +21,7 @@ variable "production_objects" {
   description = "The Tanium system package objects inside the production bucket."
   default = [
     "RPM-GPG-KEY-Tanium",
+    "tanium-init.dat",
     "TaniumClient-*",
     "taniumclient_*",
   ]
@@ -37,6 +38,7 @@ variable "staging_objects" {
   description = "The Tanium system packages inside the staging bucket."
   default = [
     "RPM-GPG-KEY-Tanium",
+    "tanium-init.dat",
     "TaniumClient-*",
     "taniumclient_*",
   ]


### PR DESCRIPTION
## 🗣 Description ##

This pull requests adds to this role:
* A Tanium initialization file that is installed
* The installation and trusting (at the OS level) of the DHS/Treasury PKI bundle

## 💭 Motivation and context ##

The initialization file contains a registration secret that was found to be necessary when debugging with the VENOM team.

Without these certificates the Tanium clients in the COOL could not communicate with the VENOM Tanium server at all.  With these certificates the SYN packets could be seen travelling from the COOL, through the site-to-site VPN tunnel, and reaching the VENOM Tanium server; however, no ACK packets were received by the COOL systems.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

Without the registration secret in the initialization it was not possible to communicate at all with the Tanium server.  With the initialization file we could see the communication begin.

Without the DHS PKI certificates the Tanium clients in the COOL could not communicate with the VENOM Tanium server at all. With these certificates the SYN packets could be seen travelling from the COOL, through the site-to-site VPN tunnel, and reaching the VENOM Tanium server; however, no ACK packets were received by the COOL systems.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
