### PR TITLE
Update test user Terraform code due to recent cisagov/ansible-role-cdm-certificates changes

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -41,5 +41,10 @@ galaxy_info:
 dependencies:
   - src: https://github.com/cisagov/ansible-role-dhs-certificates
     name: dhs_certificates
+  # Note that the value of third_party_bucket_name used for this
+  # Ansible role will trickle down to this dependent role.  For
+  # details, see the last paragraph of this section of the Ansible
+  # documentation:
+  # https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#using-roles-at-the-play-level
   - src: https://github.com/cisagov/ansible-role-cdm-certificates
     name: cdm_certificates

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -50,28 +50,6 @@ provider "aws" {
   }
 }
 
-# The provider used to create policies and roles that can read
-# parameters from AWS SSM Parameter Store in staging.
-provider "aws" {
-  alias  = "images_staging_ssm"
-  region = var.aws_region
-  assume_role {
-    role_arn     = data.terraform_remote_state.images_staging_ssm.outputs.provisionparameterstorereadroles_role.arn
-    session_name = local.caller_user_name
-  }
-}
-
-# The provider used to create policies and roles that can read
-# parameters from AWS SSM Parameter Store in production.
-provider "aws" {
-  alias  = "images_production_ssm"
-  region = var.aws_region
-  assume_role {
-    role_arn     = data.terraform_remote_state.images_production_ssm.outputs.provisionparameterstorereadroles_role.arn
-    session_name = local.caller_user_name
-  }
-}
-
 # The provider used to create the test user
 provider "aws" {
   alias  = "users"

--- a/terraform/remote_states.tf
+++ b/terraform/remote_states.tf
@@ -34,6 +34,19 @@ data "terraform_remote_state" "images_production" {
   workspace = "production"
 }
 
+data "terraform_remote_state" "ansible_role_cdm_certificates" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "ansible-role-cdm-certificates/terraform.tfstate"
+  }
+}
+
 data "terraform_remote_state" "users" {
   backend = "s3"
 

--- a/terraform/remote_states.tf
+++ b/terraform/remote_states.tf
@@ -34,36 +34,6 @@ data "terraform_remote_state" "images_production" {
   workspace = "production"
 }
 
-data "terraform_remote_state" "images_staging_ssm" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-readstate"
-    region         = "us-east-1"
-    key            = "cool-images-parameterstore/terraform.tfstate"
-  }
-
-  workspace = "staging"
-}
-
-data "terraform_remote_state" "images_production_ssm" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-readstate"
-    region         = "us-east-1"
-    key            = "cool-images-parameterstore/terraform.tfstate"
-  }
-
-  workspace = "production"
-}
-
 data "terraform_remote_state" "users" {
   backend = "s3"
 

--- a/terraform/user.tf
+++ b/terraform/user.tf
@@ -33,3 +33,23 @@ resource "aws_iam_role_policy_attachment" "thirdpartybucketread_staging" {
   policy_arn = module.staging_bucket_access.policy.arn
   role       = module.user.staging_role.name
 }
+
+# Attach 3rd party S3 bucket read-only policy from
+# cisagov/ansible-role-cdm-certificates to the production role used by
+# the test user
+resource "aws_iam_role_policy_attachment" "thirdpartybucketread_certificates_production" {
+  provider = aws.images_production_provisionaccount
+
+  policy_arn = data.terraform_remote_state.ansible_role_cdm_certificates.outputs.production_bucket_policy.arn
+  role       = module.user.production_role.name
+}
+
+# Attach 3rd party S3 bucket read-only policy from
+# cisagov/ansible-role-cdm-certificates to the staging role used by
+# the test user
+resource "aws_iam_role_policy_attachment" "thirdpartybucketread_certificates_staging" {
+  provider = aws.images_staging_provisionaccount
+
+  policy_arn = data.terraform_remote_state.ansible_role_cdm_certificates.outputs.staging_bucket_policy.arn
+  role       = module.user.staging_role.name
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Terraform code defining the CI test user for this Ansible role to account for the changes in cisagov/ansible-role-cdm-certificates#7.

## 💭 Motivation and context ##

In cisagov/ansible-role-cdm-certificates#7 the CDM certificates were moved to a private S3 bucket; therefore, that role was given a test user with IAM permissions allowing it to retrieve the CDM certificates from the bucket.  Since this Ansible role has a dependency on [cisagov/ansible-role-cdm-certificates](https://github.com/cisagov/ansible-role-cdm-certificates), its test user must also have those permissions.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All new and existing tests pass.
