### PR TITLE
Use latest version of Tanium Client system packages and support Amazon Linux 2023

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,10 +24,9 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
-    # We do not have a package for Amazon Linux 2023.
-    # - name: Amazon Linux
-    #   versions:
-    #     - "2023"
+    - name: Amazon Linux
+      versions:
+        - "2023"
     - name: Debian
       versions:
         - buster
@@ -38,7 +37,7 @@ galaxy_info:
       versions:
         - "37"
         - "38"
-    # Kali is based on Debian Bookworm, which is not yet supported by
+    # Kali is based on Debian Testing, which is not supported by
     # Tanium.
     # - name: Kali
     #   versions:

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -10,16 +10,15 @@ dependency:
 driver:
   name: docker
 platforms:
-  # We do not have a package for Amazon Linux 2023.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-amazonlinux2023-ansible:latest
-  #   name: amazonlinux2023-systemd
-  #   platform: amd64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: geerlingguy/docker-debian10-ansible:latest
@@ -38,16 +37,16 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # Debian Bookworm is not yet supported by Tanium
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: cisagov/docker-debian12-ansible:latest
-  #   name: debian12-systemd
-  #   platform: amd64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: cisagov/docker-debian12-ansible:latest
+    name: debian12-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # Kali is based on Debian Testing, which is not supported by Tanium.
   # - cgroupns_mode: host
   #   command: /lib/systemd/systemd
   #   image: cisagov/docker-kali-ansible:latest

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,3 @@
+---
+# The name of the S3 object corresponding to the Tanium system package
+package_object_name: TaniumClient-7.4.10.1075-1.amzn2023.0.20230503.x86_64.rpm

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
 # The name of the S3 object corresponding to the Tanium system package
-package_object_name: taniumclient_7.4.10.1060-{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}_amd64.deb
+package_object_name: taniumclient_7.4.10.1075-{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}_amd64.deb

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,3 @@
 ---
 # The name of the S3 object corresponding to the Tanium system package
-package_object_name: TaniumClient-7.4.10.1060-1.rhe9.x86_64.rpm
+package_object_name: TaniumClient-7.4.10.1075-1.rhe9.x86_64.rpm


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Updates the Ansible role to use the latest versions of the Tanium Client system packages
- Updates the Ansible role to support Amazon Linux 2023

## 💭 Motivation and context ##

- cisagov/openvpn-packer#101 encountered [a build error](https://github.com/cisagov/openvpn-packer/actions/runs/8269715526/job/22625730202?pr=101#step:16:540) because the old set of system packages did not include one for Debian Bookworm.  I was able to verify during the testing for cisagov/openvpn-packer#101 that these changes fix the build error.
- We now have an installer for Amazon Linux 2023, so we may as well support it.

## 🧪 Testing ##

All automated tests pass.  I was also able to verify during the testing for cisagov/openvpn-packer#101 that these changes fix the build error that was seen there.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.